### PR TITLE
feat: make action more flexible and fix an edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Provide a custom path for the Dockerfile
 ```yaml
 uses: fmaule/generate-build-manifest@v2
 with:
-  # imagining you have a libs folder with the service inside of it 
+  # assuming you have a 'libs' folder that includes the service
   dockerfile-path: './libs/service1'
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 | ----------------------- | ----------------------------------------------- | --------------------- | ------------ |
 | **`scm-info`**          | Get information from SCM/GitHub                 | `true`                | **false**    |
 | **`package-info`**      | Get information from package.json               | `true`                | **false**    |
+| **`project-name`**      | Project name                                    | `""`                  | **false**    |
+| **`project-version`**   | Project version                                 | `""`                  | **false**    |
 | **`action-info`**       | Write GitHub action info in the manifest        | `true`                | **false**    |
 | **`append-dockerfile`** | Automatically append COPY command in Dockerfile | `true`                | **false**    |
 | **`manifest-file`**     | Manifest filename                               | `build-manifest.json` | **false**    |
@@ -40,6 +42,16 @@ Simple example:
 uses: fmaule/generate-build-manifest@v2
 with:
   action-info: false # disable writing action information to manifest (just an example)
+```
+
+Pass name and version instead of reading it from the package.json
+
+```yaml
+uses: fmaule/generate-build-manifest@v2
+with:
+  package-info: false
+  project-name: 'my-project'
+  project-version: '1.0.0'
 ```
 
 ### Full Usage Example
@@ -72,16 +84,21 @@ Any contribution or suggestion is more than welcome. Please open an issue or sub
 ## 📚 FAQs
 
 **Q: What is the purpose of the `build-manifest.json`?**
+
 - **A:** The `build-manifest.json` provides a comprehensive overview of the container's build process and its contents. This is particularly valuable when deploying multiple docker images or microservices. By having a manifest inside the image, you get an in-depth view of the build specifications and the contents of the container. This can be extremely helpful for debugging, tracking builds, and ensuring consistent deployments.
 
 **Q: How can the `build-manifest.json` be utilized in real-world scenarios?**
+
 - **A:** The `build-manifest.json` can be served over HTTP, making it an effective health check or probe for Kubernetes pods. Additionally, it can be used for inventory purposes, providing a snapshot of the state of the application and its dependencies at the time of the build.
 
 **Q: Why is the `append-dockerfile` input useful?**
+
 - **A:** The `append-dockerfile` input automatically adds a COPY command to your Dockerfile, ensuring the `build-manifest.json` is included in your container during the build phase. This saves you the manual step of adding it yourself and ensures that the manifest is always present in your built containers.
 
 **Q: I already have a build process in place. How hard is it to integrate this action into my workflow?**
+
 - **A:** Integration is straightforward. All you need to do is add a few lines to your GitHub workflow YAML file. This action is designed to be plug-and-play, making it easy to adopt without major changes to your existing setup.
 
 **Q: What if I don't want certain information, like GitHub action details, in my manifest?**
+
 - **A:** This action is flexible. You can easily customize the content of the manifest by using the provided inputs. For instance, if you don't want the GitHub action details in your manifest, you can set the `action-info` input to `false`. to false.

--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ Any contribution or suggestion is more than welcome. Please open an issue or sub
 
 **Q: What if I don't want certain information, like GitHub action details, in my manifest?**
 
-- **A:** This action is flexible. You can easily customize the content of the manifest by using the provided inputs. For instance, if you don't want the GitHub action details in your manifest, you can set the `action-info` input to `false`. to false.
+- **A:** This action is flexible. You can easily customize the content of the manifest by using the provided inputs. For instance, if you don't want the GitHub action details in your manifest, you can set the `action-info` input to `false`.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 | ----------------------- | ----------------------------------------------- | --------------------- | ------------ |
 | **`scm-info`**          | Get information from SCM/GitHub                 | `true`                | **false**    |
 | **`package-info`**      | Get information from package.json               | `true`                | **false**    |
-| **`project-name`**      | Project name                                    | `""`                  | **false**    |
-| **`project-version`**   | Project version                                 | `""`                  | **false**    |
 | **`action-info`**       | Write GitHub action info in the manifest        | `true`                | **false**    |
 | **`append-dockerfile`** | Automatically append COPY command in Dockerfile | `true`                | **false**    |
+| **`dockerfile-path`**   | Provide the (relative) path for the Dockerfile  | `.`                   | **false**    |
 | **`manifest-file`**     | Manifest filename                               | `build-manifest.json` | **false**    |
 
 <!-- end inputs -->
@@ -44,14 +43,13 @@ with:
   action-info: false # disable writing action information to manifest (just an example)
 ```
 
-Pass name and version instead of reading it from the package.json
+Provide a custom path for the Dockerfile
 
 ```yaml
 uses: fmaule/generate-build-manifest@v2
 with:
-  package-info: false
-  project-name: 'my-project'
-  project-version: '1.0.0'
+  # imagining you have a libs folder with the service inside of it 
+  dockerfile-path: './libs/service1'
 ```
 
 ### Full Usage Example

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Write GitHub action info in the manifest'
     required: false
     default: 'true'
+  dockerfile-path:
+    description: 'Dockerfile path'
+    required: false
+    default: '.'
   append-dockerfile:
     description: 'Automatically append COPY command in Dockerfile'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: 'Manifest filename'
     required: false
     default: 'build-manifest.json'
+outputs:
+  manifest-content:
+    description: 'The content of the generated manifest'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29832,13 +29832,16 @@ try {
         ...(writePackageInfo && getPackageInfo()),
         ...(writeActionInfo && getActionInfo()),
     };
-    fs_1.default.writeFileSync(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+    const manifestContent = `${JSON.stringify(manifest, null, 2)}\n`;
+    fs_1.default.writeFileSync(manifestFile, manifestContent, "utf-8");
     if (appendDockerFile) {
         writeDockerFile(manifestFile);
     }
     appendDockerFile
-        ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile`)
+        ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile new`)
         : core.info(`📝 Manifest: ${manifestFile}`);
+    core.info(`Manifest content \n${manifestContent}\n`);
+    core.setOutput("manifest-content", manifestContent);
 }
 catch (e) {
     core.error(e);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29810,11 +29810,11 @@ const getScm = () => {
     };
     return { scm };
 };
-const writeDockerFile = (manifestName) => {
+const writeDockerFile = (dockerfilePath, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-    const dockerFile = `${process.env.GITHUB_WORKSPACE}/Dockerfile`;
+    const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
     if (!fs_1.default.existsSync(dockerFile)) {
-        throw new Error("Docker file not found. Make sure you have one or turn off the option if not needed (see README)");
+        throw new Error("Dockerfile not found. Make sure you have one or turn off the option if not needed (see README)");
     }
     core.debug(`Appending command to docker file (${dockerFile}): ${dockerCommand}`);
     fs_1.default.appendFileSync(dockerFile, dockerCommand);
@@ -29825,6 +29825,7 @@ try {
     const writeScm = core.getBooleanInput("scm-info");
     const writePackageInfo = core.getBooleanInput("package-info");
     const writeActionInfo = core.getBooleanInput("action-info");
+    const dockerFilePath = core.getInput("dockerfile-path");
     const appendDockerFile = core.getBooleanInput("append-dockerfile");
     const manifestFile = core.getInput("manifest-file");
     core.debug(`Manifest ${manifestFile} being generated with SCM: ${writeScm}, package.json info: ${writePackageInfo}, action info: ${writeActionInfo}`);
@@ -29838,7 +29839,7 @@ try {
     const manifestContent = `${JSON.stringify(manifest, null, 2)}\n`;
     fs_1.default.writeFileSync(manifestFile, manifestContent, "utf-8");
     if (appendDockerFile) {
-        writeDockerFile(manifestFile);
+        writeDockerFile(dockerFilePath, manifestFile);
     }
     appendDockerFile
         ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile new`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -29813,6 +29813,9 @@ const getScm = () => {
 const writeDockerFile = (manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
     const dockerFile = `${process.env.GITHUB_WORKSPACE}/Dockerfile`;
+    if (!fs_1.default.existsSync(dockerFile)) {
+        throw new Error("Docker file not found. Make sure you have one or turn off the option if not needed (see README)");
+    }
     core.debug(`Appending command to docker file (${dockerFile}): ${dockerCommand}`);
     fs_1.default.appendFileSync(dockerFile, dockerCommand);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -29814,7 +29814,7 @@ const writeDockerFile = (dockerfilePath, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
     const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
     if (!fs_1.default.existsSync(dockerFile)) {
-        throw new Error("Dockerfile not found. Make sure you have one or turn off the option if not needed (see README)");
+        throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");
     }
     core.debug(`Appending command to docker file (${dockerFile}): ${dockerCommand}`);
     fs_1.default.appendFileSync(dockerFile, dockerCommand);
@@ -29842,9 +29842,8 @@ try {
         writeDockerFile(dockerFilePath, manifestFile);
     }
     appendDockerFile
-        ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile new`)
+        ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile`)
         : core.info(`📝 Manifest: ${manifestFile}`);
-    core.info(`Manifest content \n${manifestContent}\n`);
     core.setOutput("manifest-content", manifestContent);
 }
 catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,11 @@ const getScm = (): { scm: SCM | null } => {
 const writeDockerFile = (manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
   const dockerFile = `${process.env.GITHUB_WORKSPACE}/Dockerfile`;
+  if (!fs.existsSync(dockerFile)) {
+    throw new Error(
+      "Docker file not found. Make sure you have one or turn off the option if not needed (see README)",
+    );
+  }
   core.debug(
     `Appending command to docker file (${dockerFile}): ${dockerCommand}`,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,19 +95,19 @@ try {
     ...(writeActionInfo && getActionInfo()),
   };
 
-  fs.writeFileSync(
-    manifestFile,
-    `${JSON.stringify(manifest, null, 2)}\n`,
-    "utf-8",
-  );
+  const manifestContent = `${JSON.stringify(manifest, null, 2)}\n`;
+  fs.writeFileSync(manifestFile, manifestContent, "utf-8");
 
   if (appendDockerFile) {
     writeDockerFile(manifestFile);
   }
 
   appendDockerFile
-    ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile`)
+    ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile new`)
     : core.info(`📝 Manifest: ${manifestFile}`);
+
+  core.info(`Manifest content \n${manifestContent}\n`);
+  core.setOutput("manifest-content", manifestContent);
 } catch (e) {
   core.error(e as Error);
   core.setFailed((e as Error).message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,12 +63,12 @@ const getScm = (): { scm: SCM | null } => {
   return { scm };
 };
 
-const writeDockerFile = (manifestName: string) => {
+const writeDockerFile = (dockerfilePath: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-  const dockerFile = `${process.env.GITHUB_WORKSPACE}/Dockerfile`;
+  const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
   if (!fs.existsSync(dockerFile)) {
     throw new Error(
-      "Docker file not found. Make sure you have one or turn off the option if not needed (see README)",
+      "Dockerfile not found. Make sure you have one or turn off the option if not needed (see README)",
     );
   }
   core.debug(
@@ -84,6 +84,7 @@ try {
   const writeScm = core.getBooleanInput("scm-info");
   const writePackageInfo = core.getBooleanInput("package-info");
   const writeActionInfo = core.getBooleanInput("action-info");
+  const dockerFilePath = core.getInput("dockerfile-path");
   const appendDockerFile = core.getBooleanInput("append-dockerfile");
   const manifestFile = core.getInput("manifest-file");
 
@@ -104,14 +105,13 @@ try {
   fs.writeFileSync(manifestFile, manifestContent, "utf-8");
 
   if (appendDockerFile) {
-    writeDockerFile(manifestFile);
+    writeDockerFile(dockerFilePath, manifestFile);
   }
 
   appendDockerFile
-    ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile new`)
+    ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile`)
     : core.info(`📝 Manifest: ${manifestFile}`);
 
-  core.info(`Manifest content \n${manifestContent}\n`);
   core.setOutput("manifest-content", manifestContent);
 } catch (e) {
   core.error(e as Error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const writeDockerFile = (dockerfilePath: string, manifestName: string) => {
   const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
   if (!fs.existsSync(dockerFile)) {
     throw new Error(
-      "Dockerfile not found. Make sure you have one or turn off the option if not needed (see README)",
+      "Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)",
     );
   }
   core.debug(


### PR DESCRIPTION
This PR:
- new parameter `dockerfile-path`: adds the possibility to specify a custom Dockerfile path (can be useful if a project have the dockerfile inside a folder that is not the project root) - add also an example in the readme
- new output `manifest-content`: just adds the content of the generated file as an output of the action. Were useful to me to debug in the log what actually was written
- add a check in the `writeDockerFile` step, before it was not checking if the file actually existed, and `fs.appendFileSync` created a brand new file if it doesn't find the one provided as first parameter

