### PR TITLE
fix: relative docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 
 <!-- start inputs -->
 
-| **Input**               | **Description**                                 | **Default**           | **Required** |
-| ----------------------- | ----------------------------------------------- | --------------------- | ------------ |
-| **`scm-info`**          | Get information from SCM/GitHub                 | `true`                | **false**    |
-| **`package-info`**      | Get information from package.json               | `true`                | **false**    |
-| **`action-info`**       | Write GitHub action info in the manifest        | `true`                | **false**    |
-| **`append-dockerfile`** | Automatically append COPY command in Dockerfile | `true`                | **false**    |
-| **`dockerfile-path`**   | Provide the (relative) path for the Dockerfile  | `.`                   | **false**    |
-| **`manifest-file`**     | Manifest filename                               | `build-manifest.json` | **false**    |
+| **Input**               | **Description**                                                                       | **Default**           | **Required** |
+| ----------------------- | ------------------------------------------------------------------------------------- | --------------------- | ------------ |
+| **`scm-info`**          | Get information from SCM/GitHub                                                       | `true`                | **false**    |
+| **`package-info`**      | Get information from package.json                                                     | `true`                | **false**    |
+| **`action-info`**       | Write GitHub action info in the manifest                                              | `true`                | **false**    |
+| **`append-dockerfile`** | Automatically append COPY command in Dockerfile                                       | `true`                | **false**    |
+| **`working-directory`** | Path (relative) where the dockerfile is stored and where the manifest will be written | `.`                   | **false**    |
+| **`manifest-file`**     | Manifest filename                                                                     | `build-manifest.json` | **false**    |
 
 <!-- end inputs -->
 
@@ -49,7 +49,7 @@ Provide a custom path for the Dockerfile
 uses: fmaule/generate-build-manifest@v2
 with:
   # assuming you have a 'libs' folder that includes the service
-  dockerfile-path: './libs/service1'
+  working-directory: './libs/service1'
 ```
 
 ### Full Usage Example

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,6 @@ inputs:
     description: 'Write GitHub action info in the manifest'
     required: false
     default: 'true'
-  dockerfile-path:
-    description: 'Dockerfile path'
-    required: false
-    default: '.'
   append-dockerfile:
     description: 'Automatically append COPY command in Dockerfile'
     required: false
@@ -28,6 +24,10 @@ inputs:
     description: 'Manifest filename'
     required: false
     default: 'build-manifest.json'
+  working-directory:
+    description: 'Working directory, this is where the dockerfile should be and where the build-manifest will be written'
+    required: false
+    default: './'
 outputs:
   manifest-content:
     description: 'The content of the generated manifest'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29810,9 +29810,9 @@ const getScm = () => {
     };
     return { scm };
 };
-const writeDockerFile = (dockerfilePath, manifestName) => {
+const writeDockerFile = (workingDirectory, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-    const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
+    const dockerFile = `${process.env.GITHUB_WORKSPACE}/${workingDirectory}/Dockerfile`;
     if (!fs_1.default.existsSync(dockerFile)) {
         throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");
     }
@@ -29825,7 +29825,7 @@ try {
     const writeScm = core.getBooleanInput("scm-info");
     const writePackageInfo = core.getBooleanInput("package-info");
     const writeActionInfo = core.getBooleanInput("action-info");
-    const dockerFilePath = core.getInput("dockerfile-path");
+    const workingDirectory = core.getInput("working-directory");
     const appendDockerFile = core.getBooleanInput("append-dockerfile");
     const manifestFile = core.getInput("manifest-file");
     core.debug(`Manifest ${manifestFile} being generated with SCM: ${writeScm}, package.json info: ${writePackageInfo}, action info: ${writeActionInfo}`);
@@ -29837,9 +29837,9 @@ try {
         ...(writeActionInfo && getActionInfo()),
     };
     const manifestContent = `${JSON.stringify(manifest, null, 2)}\n`;
-    fs_1.default.writeFileSync(manifestFile, manifestContent, "utf-8");
+    fs_1.default.writeFileSync(`${workingDirectory}/${manifestFile}`, manifestContent, "utf-8");
     if (appendDockerFile) {
-        writeDockerFile(dockerFilePath, manifestFile);
+        writeDockerFile(workingDirectory, manifestFile);
     }
     appendDockerFile
         ? core.info(`📝 Manifest: ${manifestFile} + COPY to Dockerfile`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,9 +63,9 @@ const getScm = (): { scm: SCM | null } => {
   return { scm };
 };
 
-const writeDockerFile = (dockerfilePath: string, manifestName: string) => {
+const writeDockerFile = (workingDirectory: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-  const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
+  const dockerFile = `${process.env.GITHUB_WORKSPACE}/${workingDirectory}/Dockerfile`;
   if (!fs.existsSync(dockerFile)) {
     throw new Error(
       "Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)",
@@ -84,7 +84,7 @@ try {
   const writeScm = core.getBooleanInput("scm-info");
   const writePackageInfo = core.getBooleanInput("package-info");
   const writeActionInfo = core.getBooleanInput("action-info");
-  const dockerFilePath = core.getInput("dockerfile-path");
+  const workingDirectory = core.getInput("working-directory");
   const appendDockerFile = core.getBooleanInput("append-dockerfile");
   const manifestFile = core.getInput("manifest-file");
 
@@ -102,10 +102,14 @@ try {
   };
 
   const manifestContent = `${JSON.stringify(manifest, null, 2)}\n`;
-  fs.writeFileSync(manifestFile, manifestContent, "utf-8");
+  fs.writeFileSync(
+    `${workingDirectory}/${manifestFile}`,
+    manifestContent,
+    "utf-8",
+  );
 
   if (appendDockerFile) {
-    writeDockerFile(dockerFilePath, manifestFile);
+    writeDockerFile(workingDirectory, manifestFile);
   }
 
   appendDockerFile


### PR DESCRIPTION
> [!CAUTION]
> This is a breaking change

I realised that the `dockerfile-path` is useless, as then when in docker we run the injected command `COPY build-manifest.json` docker expects the file to be in the same folder, so I'm proposing to change this input with another one called `working-directory`, to better reflect that is going to be where to pickup the dockerfile and where will be written the manifest file