### PR TITLE
feat: custom package location and refactor dockerfile read

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 
 <!-- start inputs -->
 
-| **Input**               | **Description**                                 | **Default**           | **Required** |
-| ----------------------- | ----------------------------------------------- | --------------------- | ------------ |
-| **`scm-info`**          | Get information from SCM/GitHub                 | `true`                | **false**    |
-| **`package-info`**      | Get information from package.json               | `true`                | **false**    |
-| **`action-info`**       | Write GitHub action info in the manifest        | `true`                | **false**    |
-| **`append-dockerfile`** | Automatically append COPY command in Dockerfile | `true`                | **false**    |
-| **`dockerfile-path`**   | Provide the (relative) path for the Dockerfile  | `.`                   | **false**    |
-| **`manifest-file`**     | Manifest filename                               | `build-manifest.json` | **false**    |
+| **Input**               | **Description**                                                           | **Default**           | **Required** |
+| ----------------------- | ------------------------------------------------------------------------- | --------------------- | ------------ |
+| **`scm-info`**          | Get information from SCM/GitHub                                           | `true`                | **false**    |
+| **`package-info`**      | Get information from package.json                                         | `true`                | **false**    |
+| **`action-info`**       | Write GitHub action info in the manifest                                  | `true`                | **false**    |
+| **`package-json`**      | Provide the (relative) path for the package.json (name included)          | `./package.json`      | **false**    |
+| **`dockerfile`**        | Provide the (relative) path for the Dockerfile (name included)            | `./Dockerfile`        | **false**    |
+| **`append-dockerfile`** | Automatically append COPY command in Dockerfile                           | `true`                | **false**    |
+| **`manifest-file`**     | Manifest filename                                                         | `build-manifest.json` | **false**    |
 
 <!-- end inputs -->
 
@@ -43,13 +44,14 @@ with:
   action-info: false # disable writing action information to manifest (just an example)
 ```
 
-Provide a custom path for the Dockerfile
+Provide custom Dockerfile and package.json:
 
 ```yaml
 uses: fmaule/generate-build-manifest@v2
 with:
   # assuming you have a 'libs' folder that includes the service
-  dockerfile-path: './libs/service1'
+  dockerfile: './libs/service1/my-dockerfile'
+  package-json: './libs/service1/package.json'
 ```
 
 ### Full Usage Example

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 
 ```yaml
 - name: Generate manifest
-  uses: fmaule/generate-build-manifest@v2
+  uses: fmaule/generate-build-manifest@v3
 ```
 
 ## 📋 Prerequisites
@@ -27,8 +27,8 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 | **`scm-info`**          | Get information from SCM/GitHub                                           | `true`                | **false**    |
 | **`package-info`**      | Get information from package.json                                         | `true`                | **false**    |
 | **`action-info`**       | Write GitHub action info in the manifest                                  | `true`                | **false**    |
-| **`package-json`**      | Provide the (relative) path for the package.json (name included)          | `./package.json`      | **false**    |
-| **`dockerfile`**        | Provide the (relative) path for the Dockerfile (name included)            | `./Dockerfile`        | **false**    |
+| **`package-json`**      | Provide the path for the package.json (name included)                     | `./package.json`      | **false**    |
+| **`dockerfile`**        | Provide the path for the Dockerfile (name included)                       | `./Dockerfile`        | **false**    |
 | **`append-dockerfile`** | Automatically append COPY command in Dockerfile                           | `true`                | **false**    |
 | **`manifest-file`**     | Manifest filename                                                         | `build-manifest.json` | **false**    |
 
@@ -39,7 +39,7 @@ To use this GitHub Action, add the following step to your GitHub workflow YAML f
 Simple example:
 
 ```yaml
-uses: fmaule/generate-build-manifest@v2
+uses: fmaule/generate-build-manifest@v3
 with:
   action-info: false # disable writing action information to manifest (just an example)
 ```
@@ -47,7 +47,7 @@ with:
 Provide custom Dockerfile and package.json:
 
 ```yaml
-uses: fmaule/generate-build-manifest@v2
+uses: fmaule/generate-build-manifest@v3
 with:
   # assuming you have a 'libs' folder that includes the service
   dockerfile: './libs/service1/my-dockerfile'
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Generate manifest
-        uses: fmaule/generate-build-manifest@v2
+        uses: fmaule/generate-build-manifest@v3
         with:
           action-info: false # disable writing action information to manifest
 

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,10 @@ inputs:
     description: 'Write GitHub action info in the manifest'
     required: false
     default: 'true'
-  package-json-path:
-    description: 'Path to package.json'
+  package-json:
+    description: 'package.json path (included package.json name)'
     required: false
-    default: '.'
+    default: './package.json'
   dockerfile:
     description: 'Dockerfile path (included dockerfile name)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
     description: 'Path to package.json'
     required: false
     default: '.'
-  dockerfile-path:
-    description: 'Dockerfile path'
+  dockerfile:
+    description: 'Dockerfile path (included dockerfile name)'
     required: false
     default: '.'
   append-dockerfile:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   dockerfile:
     description: 'Dockerfile path (included dockerfile name)'
     required: false
-    default: '.'
+    default: './Dockerfile'
   append-dockerfile:
     description: 'Automatically append COPY command in Dockerfile'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Write GitHub action info in the manifest'
     required: false
     default: 'true'
+  package-json-path:
+    description: 'Path to package.json'
+    required: false
+    default: '.'
   dockerfile-path:
     description: 'Dockerfile path'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -29819,8 +29819,11 @@ const getScm = () => {
 };
 const writeDockerFile = (dockerfile, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
+    // log dockerfile path
     const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
+    core.info(`Dockerfile path: ${dockerFile}`);
     if (!fs_1.default.existsSync(dockerFile)) {
+        // list files in the workspace
         throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");
     }
     core.debug(`Appending command to docker file (${dockerFile}): ${dockerCommand}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29817,6 +29817,7 @@ const getScm = () => {
 const writeDockerFile = (dockerfile, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
     const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
+    core.info(`Dockerfile path: ${dockerFile}`);
     if (!fs_1.default.existsSync(dockerFile)) {
         throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -29771,9 +29771,6 @@ const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const getPackageInfo = (packageJsonPath) => {
     const packageJsonLocation = `${process.env.GITHUB_WORKSPACE}/${packageJsonPath}/package.json`;
-    // const packageJsonLocation = packageJsonPath
-    //   ? `${process.env.GITHUB_WORKSPACE}/${packageJsonPath}/package.json`
-    //   : `${process.env.GITHUB_WORKSPACE}/package.json`;
     const packageJson = require(packageJsonLocation);
     const { name, version } = packageJson;
     return { name, version };
@@ -29819,11 +29816,8 @@ const getScm = () => {
 };
 const writeDockerFile = (dockerfile, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-    // log dockerfile path
     const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
-    core.info(`Dockerfile path: ${dockerFile}`);
     if (!fs_1.default.existsSync(dockerFile)) {
-        // list files in the workspace
         throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");
     }
     core.debug(`Appending command to docker file (${dockerFile}): ${dockerCommand}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29784,8 +29784,8 @@ const getFilePath = (filePath) => {
 };
 const getPackageInfo = (packageJson) => {
     const packageJsonLocation = getFilePath(packageJson);
-    const packageJsonContent = require(packageJsonLocation);
-    const { name, version } = packageJsonContent;
+    const packageJsonContent = fs_1.default.readFileSync(packageJsonLocation, "utf-8");
+    const { name, version } = JSON.parse(packageJsonContent);
     return { name, version };
 };
 const getActionInfo = () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29772,12 +29772,10 @@ const github = __importStar(__nccwpck_require__(5438));
 // first we attempt to read the file from the path provided, if not found, we try to search in the GITHUB_WORKSPACE
 const getFilePath = (filePath) => {
     let fileLocation = filePath;
-    core.info(`Checking if ${fileLocation} exists`);
     if (!fs_1.default.existsSync(fileLocation)) {
         core.warning(`${fileLocation} not found, searching in the GITHUB_WORKSPACE ${process.env.GITHUB_WORKSPACE}`);
         fileLocation = `${process.env.GITHUB_WORKSPACE}/${filePath}`;
     }
-    core.info(`Checking if ${fileLocation} exists`);
     if (!fs_1.default.existsSync(fileLocation)) {
         throw new Error(`${filePath} not found in ${fileLocation}. Make sure you have one or turn off the append-dockerfile option if not needed (see README)`);
     }
@@ -29845,7 +29843,6 @@ try {
     const dockerFile = core.getInput("dockerfile");
     const appendDockerFile = core.getBooleanInput("append-dockerfile");
     const manifestFile = core.getInput("manifest-file");
-    core.info(`package.json: ${packageJson}`);
     core.debug(`Manifest ${manifestFile} being generated with SCM: ${writeScm}, package.json info: ${writePackageInfo}, action info: ${writeActionInfo}`);
     const timestamp = new Date().toISOString();
     const manifest = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29816,7 +29816,10 @@ const getScm = () => {
 };
 const writeDockerFile = (dockerfile, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-    const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
+    // if dockerfile is default (./Dockerfile), we need to get the full path, otherwise we can use only the input provided
+    const dockerFile = dockerfile === "./Dockerfile"
+        ? `${process.env.GITHUB_WORKSPACE}/${dockerfile}`
+        : dockerfile;
     core.info(`Dockerfile path: ${dockerFile}`);
     if (!fs_1.default.existsSync(dockerFile)) {
         throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");

--- a/dist/index.js
+++ b/dist/index.js
@@ -29772,10 +29772,12 @@ const github = __importStar(__nccwpck_require__(5438));
 // first we attempt to read the file from the path provided, if not found, we try to search in the GITHUB_WORKSPACE
 const getFilePath = (filePath) => {
     let fileLocation = filePath;
+    core.info(`Checking if ${fileLocation} exists`);
     if (!fs_1.default.existsSync(fileLocation)) {
         core.warning(`${fileLocation} not found, searching in the GITHUB_WORKSPACE ${process.env.GITHUB_WORKSPACE}`);
         fileLocation = `${process.env.GITHUB_WORKSPACE}/${filePath}`;
     }
+    core.info(`Checking if ${fileLocation} exists`);
     if (!fs_1.default.existsSync(fileLocation)) {
         throw new Error(`${filePath} not found in ${fileLocation}. Make sure you have one or turn off the append-dockerfile option if not needed (see README)`);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -29816,16 +29816,18 @@ const getScm = () => {
 };
 const writeDockerFile = (dockerfile, manifestName) => {
     const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-    // if dockerfile is default (./Dockerfile), we need to get the full path, otherwise we can use only the input provided
-    const dockerFile = dockerfile === "./Dockerfile"
-        ? `${process.env.GITHUB_WORKSPACE}/${dockerfile}`
-        : dockerfile;
-    core.info(`Dockerfile path: ${dockerFile}`);
-    if (!fs_1.default.existsSync(dockerFile)) {
-        throw new Error("Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)");
+    // try to read the dockerfile from the path provided, if not found, try to search in the GITHUB_WORKSPACE
+    let dockerfilePath = dockerfile;
+    if (!fs_1.default.existsSync(dockerfilePath)) {
+        core.warning(`Dockerfile not found at ${dockerfilePath}, searching in the GITHUB_WORKSPACE ${process.env.GITHUB_WORKSPACE}`);
+        dockerfilePath = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
     }
-    core.debug(`Appending command to docker file (${dockerFile}): ${dockerCommand}`);
-    fs_1.default.appendFileSync(dockerFile, dockerCommand);
+    core.info(`Dockerfile path: ${dockerfilePath}`);
+    if (!fs_1.default.existsSync(dockerfilePath)) {
+        throw new Error(`Dockerfile not found in ${dockerfilePath}. Make sure you have one or turn off the append-dockerfile option if not needed (see README)`);
+    }
+    core.debug(`Appending command to docker file (${dockerfilePath}): ${dockerCommand}`);
+    fs_1.default.appendFileSync(dockerfilePath, dockerCommand);
 };
 try {
     if (!process.env.GITHUB_WORKSPACE)

--- a/dist/index.js
+++ b/dist/index.js
@@ -29845,6 +29845,7 @@ try {
     const dockerFile = core.getInput("dockerfile");
     const appendDockerFile = core.getBooleanInput("append-dockerfile");
     const manifestFile = core.getInput("manifest-file");
+    core.info(`package.json: ${packageJson}`);
     core.debug(`Manifest ${manifestFile} being generated with SCM: ${writeScm}, package.json info: ${writePackageInfo}, action info: ${writeActionInfo}`);
     const timestamp = new Date().toISOString();
     const manifest = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-build-manifest",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-build-manifest",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-build-manifest",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "GitHub Action to generate manifest files for NodeJS projects",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,11 @@ const getScm = (): { scm: SCM | null } => {
 
 const writeDockerFile = (dockerfile: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-  const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
+  // if dockerfile is default (./Dockerfile), we need to get the full path, otherwise we can use only the input provided
+  const dockerFile =
+    dockerfile === "./Dockerfile"
+      ? `${process.env.GITHUB_WORKSPACE}/${dockerfile}`
+      : dockerfile;
   core.info(`Dockerfile path: ${dockerFile}`);
   if (!fs.existsSync(dockerFile)) {
     throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,14 @@ import {
 const getFilePath = (filePath: string) => {
   let fileLocation = filePath;
 
+  core.info(`Checking if ${fileLocation} exists`);
   if (!fs.existsSync(fileLocation)) {
     core.warning(
       `${fileLocation} not found, searching in the GITHUB_WORKSPACE ${process.env.GITHUB_WORKSPACE}`,
     );
     fileLocation = `${process.env.GITHUB_WORKSPACE}/${filePath}`;
   }
+  core.info(`Checking if ${fileLocation} exists`);
   if (!fs.existsSync(fileLocation)) {
     throw new Error(
       `${filePath} not found in ${fileLocation}. Make sure you have one or turn off the append-dockerfile option if not needed (see README)`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,12 @@ const getScm = (): { scm: SCM | null } => {
 
 const writeDockerFile = (dockerfile: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
+  // log dockerfile path
   const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
+  core.info(`Dockerfile path: ${dockerFile}`);
   if (!fs.existsSync(dockerFile)) {
+    // list files in the workspace
+
     throw new Error(
       "Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)",
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ const getScm = (): { scm: SCM | null } => {
 const writeDockerFile = (dockerfile: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
   const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
+  core.info(`Dockerfile path: ${dockerFile}`);
   if (!fs.existsSync(dockerFile)) {
     throw new Error(
       "Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,12 @@ import {
 const getFilePath = (filePath: string) => {
   let fileLocation = filePath;
 
-  core.info(`Checking if ${fileLocation} exists`);
   if (!fs.existsSync(fileLocation)) {
     core.warning(
       `${fileLocation} not found, searching in the GITHUB_WORKSPACE ${process.env.GITHUB_WORKSPACE}`,
     );
     fileLocation = `${process.env.GITHUB_WORKSPACE}/${filePath}`;
   }
-  core.info(`Checking if ${fileLocation} exists`);
   if (!fs.existsSync(fileLocation)) {
     throw new Error(
       `${filePath} not found in ${fileLocation}. Make sure you have one or turn off the append-dockerfile option if not needed (see README)`,
@@ -111,8 +109,6 @@ try {
   const dockerFile = core.getInput("dockerfile");
   const appendDockerFile = core.getBooleanInput("append-dockerfile");
   const manifestFile = core.getInput("manifest-file");
-
-  core.info(`package.json: ${packageJson}`);
 
   core.debug(
     `Manifest ${manifestFile} being generated with SCM: ${writeScm}, package.json info: ${writePackageInfo}, action info: ${writeActionInfo}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,8 @@ try {
   const appendDockerFile = core.getBooleanInput("append-dockerfile");
   const manifestFile = core.getInput("manifest-file");
 
+  core.info(`package.json: ${packageJson}`);
+
   core.debug(
     `Manifest ${manifestFile} being generated with SCM: ${writeScm}, package.json info: ${writePackageInfo}, action info: ${writeActionInfo}`,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,6 @@ import {
 
 const getPackageInfo = (packageJsonPath: string): Package => {
   const packageJsonLocation = `${process.env.GITHUB_WORKSPACE}/${packageJsonPath}/package.json`;
-  // const packageJsonLocation = packageJsonPath
-  //   ? `${process.env.GITHUB_WORKSPACE}/${packageJsonPath}/package.json`
-  //   : `${process.env.GITHUB_WORKSPACE}/package.json`;
 
   const packageJson = require(packageJsonLocation);
   const { name, version } = packageJson;
@@ -73,12 +70,8 @@ const getScm = (): { scm: SCM | null } => {
 
 const writeDockerFile = (dockerfile: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-  // log dockerfile path
   const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
-  core.info(`Dockerfile path: ${dockerFile}`);
   if (!fs.existsSync(dockerFile)) {
-    // list files in the workspace
-
     throw new Error(
       "Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)",
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,12 @@ import {
   WorkflowDispatchEvent,
 } from "@octokit/webhooks-definitions/schema";
 
-const getPackageInfo = (): Package => {
-  const packageJsonLocation = `${process.env.GITHUB_WORKSPACE}/package.json`;
+const getPackageInfo = (packageJsonPath: string): Package => {
+  const packageJsonLocation = `${process.env.GITHUB_WORKSPACE}/${packageJsonPath}/package.json`;
+  // const packageJsonLocation = packageJsonPath
+  //   ? `${process.env.GITHUB_WORKSPACE}/${packageJsonPath}/package.json`
+  //   : `${process.env.GITHUB_WORKSPACE}/package.json`;
+
   const packageJson = require(packageJsonLocation);
   const { name, version } = packageJson;
   return { name, version };
@@ -88,6 +92,7 @@ try {
   const writeScm = core.getBooleanInput("scm-info");
   const writePackageInfo = core.getBooleanInput("package-info");
   const writeActionInfo = core.getBooleanInput("action-info");
+  const packageJsonPath = core.getInput("package-json-path");
   const dockerFilePath = core.getInput("dockerfile-path");
   const appendDockerFile = core.getBooleanInput("append-dockerfile");
   const manifestFile = core.getInput("manifest-file");
@@ -101,7 +106,7 @@ try {
   const manifest: Manifest = {
     timestamp,
     ...(writeScm && getScm()),
-    ...(writePackageInfo && getPackageInfo()),
+    ...(writePackageInfo && getPackageInfo(packageJsonPath)),
     ...(writeActionInfo && getActionInfo()),
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,9 @@ const getScm = (): { scm: SCM | null } => {
   return { scm };
 };
 
-const writeDockerFile = (dockerfilePath: string, manifestName: string) => {
+const writeDockerFile = (dockerfile: string, manifestName: string) => {
   const dockerCommand = `\nCOPY ${manifestName} ./\n`;
-  const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfilePath}/Dockerfile`;
+  const dockerFile = `${process.env.GITHUB_WORKSPACE}/${dockerfile}`;
   if (!fs.existsSync(dockerFile)) {
     throw new Error(
       "Dockerfile not found. Make sure you have one or turn off the append-dockerfile option if not needed (see README)",
@@ -93,7 +93,7 @@ try {
   const writePackageInfo = core.getBooleanInput("package-info");
   const writeActionInfo = core.getBooleanInput("action-info");
   const packageJsonPath = core.getInput("package-json-path");
-  const dockerFilePath = core.getInput("dockerfile-path");
+  const dockerFile = core.getInput("dockerfile");
   const appendDockerFile = core.getBooleanInput("append-dockerfile");
   const manifestFile = core.getInput("manifest-file");
 
@@ -114,7 +114,7 @@ try {
   fs.writeFileSync(manifestFile, manifestContent, "utf-8");
 
   if (appendDockerFile) {
-    writeDockerFile(dockerFilePath, manifestFile);
+    writeDockerFile(dockerFile, manifestFile);
   }
 
   appendDockerFile

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ const getFilePath = (filePath: string) => {
 const getPackageInfo = (packageJson: string): Package => {
   const packageJsonLocation = getFilePath(packageJson);
 
-  const packageJsonContent = require(packageJsonLocation);
-  const { name, version } = packageJsonContent;
+  const packageJsonContent = fs.readFileSync(packageJsonLocation, "utf-8");
+  const { name, version } = JSON.parse(packageJsonContent);
   return { name, version };
 };
 


### PR DESCRIPTION
Changes are:
- **breaking change** -> `dockerfile-path` parameter is now `dockerfile`, this makes the action more flexible as previously the dockerfile had to be `Dockerfile`, while someone can have `my-dockerfile` as a filename
- new parameter `package-json`, similar to the above one, a path to a file (included file name) where to read the package.json -> makes this action usable in monorepos where the service name is stored in an inner package.json and not in the project root
- to make it more flexible the read of the files (dockerfile and package.json) is now done in two places, first we attempt to read based on the provided parameter, then if it fails, we check under `${process.env.GITHUB_WORKSPACE}/<provided_path>`