### PR TITLE
feat: add shortSha in SCM

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29989,8 +29989,6 @@ const getScm = () => {
     const { repository } = github.context.payload;
     const { sha, ref } = context;
     const { ssh_url, clone_url } = repository;
-    // "sha-1234567" is what you get by default by the official docker/metadata-action
-    const short_sha = `sha-${sha.slice(0, 7)}`;
     const branch = process.env.GITHUB_REF_NAME;
     const scm = {
         eventName: context.eventName,
@@ -29998,7 +29996,6 @@ const getScm = () => {
         clone_url,
         branch,
         sha,
-        short_sha,
         ref,
     };
     return { scm };

--- a/dist/index.js
+++ b/dist/index.js
@@ -29989,6 +29989,8 @@ const getScm = () => {
     const { repository } = github.context.payload;
     const { sha, ref } = context;
     const { ssh_url, clone_url } = repository;
+    // "sha-1234567" is what you get by default by the official docker/metadata-action
+    const short_sha = `sha-${sha.slice(0, 7)}`;
     const branch = process.env.GITHUB_REF_NAME;
     const scm = {
         eventName: context.eventName,
@@ -29996,6 +29998,7 @@ const getScm = () => {
         clone_url,
         branch,
         sha,
+        short_sha,
         ref,
     };
     return { scm };

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,9 @@ const getScm = (): { scm: SCM | null } => {
   const { sha, ref } = context;
   const { ssh_url, clone_url } = repository;
 
+  // "sha-1234567" is what you get by default by the official docker/metadata-action
+  const short_sha = `sha-${sha.slice(0, 7)}`;
+
   const branch = process.env.GITHUB_REF_NAME;
 
   const scm = {
@@ -82,6 +85,7 @@ const getScm = (): { scm: SCM | null } => {
     clone_url,
     branch,
     sha,
+    short_sha,
     ref,
   };
 


### PR DESCRIPTION
In our company we would like to access the short-sha (composed by "sha-<first 7 chars of git sha>").

This is what you get by default from the official [docker/metadata-action](https://github.com/docker/metadata-action?tab=readme-ov-file#typesha), that way we don't need to do logic everywhere by getting the long sha and then doing something like
```javascript
const { sha } = manifest.scm;
const shortSha = `sha-{sha.slice(0, 7)}`
```
