### PR TITLE
chore: update workflow actions to latest versions

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:  
         node-version: [22.x]  
     steps:  
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}  
-        uses: actions/setup-node@v3 
-        with:  
-          node-version: ${{ matrix.node-version }} 
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Extract branch name  
         id: extractBranch  
         shell: bash  
@@ -43,7 +43,7 @@ jobs:
           git commit -m "auto-pack action"
       - name: Push packed JS  
         if: steps.commitPackedJs.outcome == 'success'  
-        uses: ad-m/github-push-action@v0.8.0
+        uses: ad-m/github-push-action@v1.1.0
         with:  
           github_token: ${{ secrets.GITHUB_TOKEN }}  
           tags: true  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
-      - uses: teunmooij/github-versioned-release@v1.2.0
+      - uses: teunmooij/github-versioned-release@v1.2.1
         with:
           template: 'javascript-action'
         env:


### PR DESCRIPTION
## Summary

Fixes the Node.js 20 deprecation warnings surfaced during the v4.0.0 release run. GitHub is forcing Node 24 for action runners from June 2026.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-node` | `v3` | `v6` |
| `ad-m/github-push-action` | `v0.8.0` | `v1.1.0` |
| `teunmooij/github-versioned-release` | `v1.2.0` | `v1.2.1` |

## Test plan

- [ ] `pack.yml` CI passes on merge (no Node 20 deprecation warnings)
- [ ] `release.yml` passes on next release